### PR TITLE
Rename file

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -40,15 +40,20 @@ theme = "adritian-free-hugo-theme"
   URL = "#portfolio"
   weight = 3
 
+#  [[menu.header]]
+#  name = "Experience"
+#  URL = "#experience"
+#  weight = 4
+
   [[menu.header]]
   name = "Blog"
   URL = "/blog"
-  weight = 4
+  weight = 5
 
   [[menu.header]]
   name = "Contact"
   URL = "#contact"
-  weight = 5
+  weight = 6
 
   [[menu.footer]]
   name = "About"


### PR DESCRIPTION
> With v0.109.0 and earlier the basename of the site configuration file was config instead of hugo. You can use either, but should transition to the new naming convention when practical.

Updating as per https://gohugo.io/getting-started/configuration/.