### PR TITLE
preview: update theme to `108-idea-add-support-for-og-metadata`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,10 +4,9 @@ theme = "adritian-free-hugo-theme"
 
 [params]
 
-  title = 'Adritian Demo - High performance hugo theme'
-  description = 'This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications'
+  title = 'Adritian - a high performance hugo theme by Adrián Moreno'
+  description = 'This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications.'
   images = ['/img/og-img.png']
-
   sections = ["showcase", "about", "education", "experience", "client-and-work", "testimonial", "contact", "newsletter"]
 
   homepageExperienceCount = 6


### PR DESCRIPTION
⚠️ The source PR is not merged yet - this is a preview PR.
  🤖 This automated PR updates the theme submodule to a PR in the source repo: https://github.com/zetxek/adritian-free-hugo-theme/pull/110.
  🔗 Triggered by https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/update-demo-pr.yml