### PR TITLE
chore: update theme to `2818605`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -33,7 +33,6 @@ theme = "adritian-free-hugo-theme"
   footer = false
 
 [languages]
-
   [languages.en]
     disabled = false
     languageCode = 'en'
@@ -180,6 +179,7 @@ theme = "adritian-free-hugo-theme"
 # Plugins
 [params.plugins]
 
+  # CSS Plugins
   [[params.plugins.css]]
   URL = "css/custom.css"
   [[params.plugins.css]]
@@ -196,6 +196,7 @@ theme = "adritian-free-hugo-theme"
   # SCSS Plugins
   [[params.plugins.scss]]
   URL = "scss/adritian.scss"
+
 
 # theme/color style 
 [params.colorTheme]


### PR DESCRIPTION
🤖 This automated PR updates the theme submodule to the latest version: https://github.com/zetxek/adritian-free-hugo-theme/commit/28186055845c3d11b509540220c9879ce62030bb.
🔗 Triggered by https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/update-demo-pr.yml