### PR TITLE
preview: update theme to `2.x-hugo-modules`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,13 @@
 baseURL = "https://adritian-demo.vercel.app/"
 languageCode = "en"
-theme = "adritian-free-hugo-theme"
+
+[module]
+[module.hugoVersion]
+# We use hugo.Deps to list dependencies, which was added in Hugo 0.92.0
+min = "0.92.0"
+
+[[module.imports]]
+path="github.com/zetxek/adritian-free-hugo-theme"
 
 [params]
 


### PR DESCRIPTION
⚠️ The source PR is not merged yet - this is a preview PR.
  🤖 This automated PR updates the theme submodule to a PR in the source repo: https://github.com/zetxek/adritian-free-hugo-theme/pull/166.
  🔗 Triggered by https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/update-demo-pr.yml