### PR TITLE
chore: update theme to a7b8fc8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36
+require github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125213401-a7b8fc8e6d47

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36 h1:VdnbGxSErcORMTMdaLfPf7nXMNn3LQdl7u+QRzRtXz0=
-github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125211631-64928b683f36/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125213401-a7b8fc8e6d47 h1:Fn38eOfamtnQIPAZuwP6Hgq58yXfP+p/wz2nHCbYIVc=
+github.com/zetxek/adritian-free-hugo-theme v1.4.28-0.20250125213401-a7b8fc8e6d47/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 This automated PR updates the theme module to version a7b8fc8.

Changes from: https://github.com/zetxek/adritian-free-hugo-theme/commit/a7b8fc8e6d475f2b04ab1365d60ead5b6447a752
🔗 Triggered by https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/update-demo-pr.yml