### PR TITLE
Add Playwright for end-to-end testing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,8 +31,19 @@ jobs:
         npm ci
         hugo mod npm pack
         npm install
+        npm install @playwright/test
+
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-
 
     - name: Install Playwright Browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps
 
     - name: Build site

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,54 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+
+    - name: Install Hugo
+      uses: peaceiris/actions-hugo@v2
+      with:
+        hugo-version: 'latest'
+        extended: true
+
+    - name: Install dependencies
+      run: |
+        npm ci
+        hugo mod npm pack
+        npm install
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - name: Build site
+      run: hugo --minify
+
+    - name: Run Playwright tests
+      run: npx playwright test
+      env:
+        CI: true
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: |
+          playwright-report/
+          test-results/
+        retention-days: 30 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ node_modules
 # Playwright test results
 playwright-report/
 test-results/
+
+# Playwright
+/blob-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "adritian-demo",
       "version": "0.1.0",
       "devDependencies": {
+        "@playwright/test": "^1.42.1",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "bootstrap-print-css": "^1.0.0",
@@ -48,6 +49,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -711,6 +728,53 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@playwright/test": "^1.42.1",
+        "@types/node": "^20.11.24",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "bootstrap-print-css": "^1.0.0",
@@ -89,6 +90,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
+      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/anymatch": {
@@ -1036,6 +1047,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,15 @@
     "bootstrap": "^5.3.3",
     "bootstrap-print-css": "^1.0.0",
     "postcss": "^8.4.35",
-    "postcss-cli": "^11.0.0"
+    "postcss-cli": "^11.0.0",
+    "@playwright/test": "^1.42.1",
+    "@types/node": "^20.11.24"
   },
   "name": "adritian-demo",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
+  }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:1313',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  webServer: {
+    command: 'hugo server',
+    url: 'http://localhost:1313',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+}); 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test('should load successfully', async ({ page }) => {
+    await page.goto('http://localhost:1313');
+    
+    // Check if main elements are visible
+    await expect(page.locator('nav.navbar')).toBeVisible();
+    await expect(page.locator('section#showcase')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+  });
+
+  test('should have correct title', async ({ page }) => {
+    await page.goto('http://localhost:1313');
+    await expect(page).toHaveTitle("Demo site for Adritian - a high performance hugo theme by Adrián Moreno");
+  });
+
+  test('should have working navigation links', async ({ page }) => {
+    await page.goto('http://localhost:1313');
+    
+    // Check main navigation links
+    const navLinks = [
+      { selector: 'a[href="/#about"]', text: 'ABOUT' },
+      { selector: 'a[href="/#portfolio"]', text: 'PORTFOLIO' },
+      { selector: 'a[href="/blog"]', text: 'BLOG' },
+      { selector: 'a[href="/#contact"]', text: 'CONTACT' }
+    ];
+
+    for (const link of navLinks) {
+      const element = page.locator(link.selector).first();
+      await expect(element).toBeVisible();
+      await expect(element).toHaveText(link.text);
+    }
+  });
+}); 


### PR DESCRIPTION
This pull request introduces Playwright for end-to-end testing and includes configuration, dependencies, and initial test cases. The most important changes are outlined below:

### Playwright Configuration and Setup

* **`.github/workflows/playwright.yml`**: Added a GitHub Actions workflow to run Playwright tests on push and pull requests to the `main` branch. This includes steps for setting up the environment, installing dependencies, building the site, running tests, and uploading test results.
* **`playwright.config.ts`**: Added Playwright configuration file to define test directory, parallel execution, retries, reporters, and browser projects (Chromium, Firefox, WebKit). Configured a web server to run Hugo during tests.

### Dependencies and Scripts

* **`package.json`**: Added Playwright and Node.js types as development dependencies. Introduced new npm scripts for running Playwright tests (`test:e2e`, `test:e2e:ui`, `test:e2e:debug`).

### Initial Test Cases

* **`tests/home.spec.ts`**: Added initial Playwright test cases for the home page, including checks for successful loading, correct title, and working navigation links.