### PR TITLE
[auto] Update Hugo modules @v1.5.8 → @v1.5.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.5.8
+require github.com/zetxek/adritian-free-hugo-theme v1.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.5.8 h1:C95Trt+AMtF+OLUdBSbR7Y2+b6Sk5k8PuxMvlUseotY=
-github.com/zetxek/adritian-free-hugo-theme v1.5.8/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.5.9 h1:ha9IarxVvAPse7KDwD/vZfOpJ7utAAD+YgPGtk8YQHk=
+github.com/zetxek/adritian-free-hugo-theme v1.5.9/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.5.8 to @v1.5.9
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml