### PR TITLE
[auto] Update Hugo modules @v1.6.0 → @v1.6.0

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.5.13 h1:qyL2aZ1hU4nPyUa0b+XIx5n8acJQjKZH9jyokBUIEic=
-github.com/zetxek/adritian-free-hugo-theme v1.5.13/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
 github.com/zetxek/adritian-free-hugo-theme v1.6.0 h1:dWqqaUp6ayO2epBqSgnjBG83L0hjrpn2zLUIAe+F3b0=
 github.com/zetxek/adritian-free-hugo-theme v1.6.0/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "adritian-demo",
       "version": "0.1.0",
       "devDependencies": {
+        "@zetxek/adritian-theme-helper": "^1.0.3",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "bootstrap-print-css": "^1.0.0",
@@ -72,6 +73,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@zetxek/adritian-theme-helper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@zetxek/adritian-theme-helper/-/adritian-theme-helper-1.0.3.tgz",
+      "integrity": "sha512-GPaZMpgVrrIBxEOcXIUWfyZ2S9PFW2do/cCFQFFphTl/Dv/TM8sCr/YKV+LVZp0JHAfGKlNOvnRkgt5puNmp7w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "adritian-download-content": "dist/scripts/download-content.js"
       }
     },
     "node_modules/anymatch": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "comments": {
     "dependencies": {},
     "devDependencies": {
+      "@zetxek/adritian-theme-helper": "github.com/zetxek/adritian-free-hugo-theme",
       "autoprefixer": "github.com/zetxek/adritian-free-hugo-theme",
       "bootstrap": "github.com/zetxek/adritian-free-hugo-theme",
       "bootstrap-print-css": "github.com/zetxek/adritian-free-hugo-theme",
@@ -11,6 +12,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@zetxek/adritian-theme-helper": "^1.0.3",
     "autoprefixer": "^10.4.17",
     "bootstrap": "^5.3.3",
     "bootstrap-print-css": "^1.0.0",


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.6.0 to @v1.6.0
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml