### PR TITLE
[auto] Update Hugo modules @v1.6.1 → @v1.6.1

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.6.1-0.20250215195840-19f21af281d7 h1:aYIVbEM9MuIsUHQFtLSlhQHQ6AlDZT1HtmcNnvI4aXQ=
-github.com/zetxek/adritian-free-hugo-theme v1.6.1-0.20250215195840-19f21af281d7/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
 github.com/zetxek/adritian-free-hugo-theme v1.6.1 h1:sLJvpaYUzSw9D+aqvA7+T27z8kJ7Q8h9PZQHiZTyD50=
 github.com/zetxek/adritian-free-hugo-theme v1.6.1/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "adritian-demo",
       "version": "0.1.0",
       "devDependencies": {
+        "@zetxek/adritian-theme-helper": "^1.0.3",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "bootstrap-print-css": "^1.0.0",
@@ -72,6 +73,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@zetxek/adritian-theme-helper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@zetxek/adritian-theme-helper/-/adritian-theme-helper-1.0.3.tgz",
+      "integrity": "sha512-GPaZMpgVrrIBxEOcXIUWfyZ2S9PFW2do/cCFQFFphTl/Dv/TM8sCr/YKV+LVZp0JHAfGKlNOvnRkgt5puNmp7w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "adritian-download-content": "dist/scripts/download-content.js"
       }
     },
     "node_modules/anymatch": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "comments": {
     "dependencies": {},
     "devDependencies": {
+      "@zetxek/adritian-theme-helper": "github.com/zetxek/adritian-free-hugo-theme",
       "autoprefixer": "github.com/zetxek/adritian-free-hugo-theme",
       "bootstrap": "github.com/zetxek/adritian-free-hugo-theme",
       "bootstrap-print-css": "github.com/zetxek/adritian-free-hugo-theme",
@@ -11,6 +12,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@zetxek/adritian-theme-helper": "^1.0.3",
     "autoprefixer": "^10.4.17",
     "bootstrap": "^5.3.3",
     "bootstrap-print-css": "^1.0.0",


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.6.1 to @v1.6.1
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml