### PR TITLE
Update to v1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.6.3-0.20250228071203-3ccbdf9c16d9
+require github.com/zetxek/adritian-free-hugo-theme v1.7.0
 
 // for local development
 //replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250227091716-069dacf257b7 
 github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250227091716-069dacf257b7/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
 github.com/zetxek/adritian-free-hugo-theme v1.6.3-0.20250228071203-3ccbdf9c16d9 h1:iy06iXY49acwfZj2JIEHU21FTzHYuWOEpxlclMqzMw0=
 github.com/zetxek/adritian-free-hugo-theme v1.6.3-0.20250228071203-3ccbdf9c16d9/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.0 h1:5aY8CB5NPtPnt1JVJYG9elCEpyESRw5wOqwnIldHfyE=
+github.com/zetxek/adritian-free-hugo-theme v1.7.0/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
update to released version for https://github.com/zetxek/adritian-free-hugo-theme/pull/222.