### PR TITLE
[auto] Update Hugo modules @v1.7.0 → @v1.7.0

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250223211253-0f5ccaccdd9d h1:EzeMW+A7ibs0G6qagiXtI34oz9p+e3S7cJWuSR0N1yk=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250223211253-0f5ccaccdd9d/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250223212053-1fa43b865ad6 h1:KnNi4QO5/VVC1fxBsIXgCRQda96XR1K9yxOTXBxdzKY=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250223212053-1fa43b865ad6/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250226194042-d9261eab5cec h1:cV6iY0bePCO35C8VDAtfS10DDrQQZOKFmx7lTwpk64k=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250226194042-d9261eab5cec/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250227091716-069dacf257b7 h1:gfzQM6Vane8yL2L3nwNRchE3mq7fy4/HnlnOIk+g4E8=
-github.com/zetxek/adritian-free-hugo-theme v1.6.2-0.20250227091716-069dacf257b7/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
-github.com/zetxek/adritian-free-hugo-theme v1.6.3-0.20250228071203-3ccbdf9c16d9 h1:iy06iXY49acwfZj2JIEHU21FTzHYuWOEpxlclMqzMw0=
-github.com/zetxek/adritian-free-hugo-theme v1.6.3-0.20250228071203-3ccbdf9c16d9/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
 github.com/zetxek/adritian-free-hugo-theme v1.7.0 h1:5aY8CB5NPtPnt1JVJYG9elCEpyESRw5wOqwnIldHfyE=
 github.com/zetxek/adritian-free-hugo-theme v1.7.0/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.0 to @v1.7.0
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml