### PR TITLE
Add 'medium' icon link to blog icons documentation

### DIFF
--- a/content/blog/icons.md
+++ b/content/blog/icons.md
@@ -36,6 +36,7 @@ You can see them rendered here:
 - `codepen`: {{< link icon="codepen" url="https://example.com" >}}
 - `yelp`: {{< link icon="yelp" url="https://example.com" >}}
 - `cloud-arrow-down`: {{< link icon="cloud-arrow-down" url="https://example.com" >}}
+- `medium`: {{< link icon="medium" url="https://example.com" >}}
 
 Do you need more icons?
 You can check this github issue to check how to [add your own](https://github.com/zetxek/adritian-free-hugo-theme/pull/169), or if it's relevant for the community you can request one [via the issue tracker like @klangborste did](https://github.com/zetxek/adritian-free-hugo-theme/issues/168). 


### PR DESCRIPTION
Related to https://github.com/zetxek/adritian-free-hugo-theme/pull/242