### PR TITLE
Add new icons 'stack-overflow' and 'meetup' to blog icons documentation; update shortcodes for image width and height parameters

### DIFF
--- a/content/blog/icons.md
+++ b/content/blog/icons.md
@@ -37,6 +37,10 @@ You can see them rendered here:
 - `yelp`: {{< link icon="yelp" url="https://example.com" >}}
 - `cloud-arrow-down`: {{< link icon="cloud-arrow-down" url="https://example.com" >}}
 - `medium`: {{< link icon="medium" url="https://example.com" >}}
+- `stack-overflow`: {{< link icon="stack-overflow" url="https://example.com" >}}
+- `meetup`: {{< link icon="meetup" url="https://example.com" >}}
+
+
 
 Do you need more icons?
 You can check this github issue to check how to [add your own](https://github.com/zetxek/adritian-free-hugo-theme/pull/169), or if it's relevant for the community you can request one [via the issue tracker like @klangborste did](https://github.com/zetxek/adritian-free-hugo-theme/issues/168). 

--- a/content/blog/shortcodes.md
+++ b/content/blog/shortcodes.md
@@ -91,8 +91,12 @@ The shortcodes can be customized with different arguments:
     - `intro_description` - Contains the HTML content or description text for the about section. Falls back to the content from site data if not provided.
 
     - `imgSrc` - Specifies the path to the image displayed in the about section. Falls back to the image defined in site data if not provided.
- 
-    - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one)
+
+    - `imgWidth` - Specifies the width for the image.
+
+    - `imgHeight` - Specifies the height for the image.
+
+    - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one) This is only considered if neither imgWidth nor imgHeight is used.
 
     - Primary Button Arguments
       - `button1_enable` - Boolean value to show or hide the primary button. Defaults to the value from site data.
@@ -134,7 +138,9 @@ The shortcodes can be customized with different arguments:
     - `button_url`: Target URL for the button. Falls back to the URL from site data.
   - **Image Configuration**:
     - `imgSrc`: Specifies the path to the image displayed in the showcase section. Falls back to the image defined in site data.
-    - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one)
+    - `imgWidth` - Specifies the width for the image.
+    - `imgHeight` - Specifies the height for the image.
+    - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one) This is only considered if neither imgWidth nor imgHeight is used.
   - **Social Media**:
     - `social_links`: Array of social media platform links to display at the bottom of the showcase. Each item should have a URL and icon property.
   - **Inner Content**:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.3
+require github.com/zetxek/adritian-free-hugo-theme v1.7.5
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/zetxek/adritian-free-hugo-theme v1.7.3 h1:ox0E4F5OHTg0Vhwr8gi7MBgzRcy2UIDB9aanAd13UWo=
 github.com/zetxek/adritian-free-hugo-theme v1.7.3/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.5 h1:fXC4EzqPkLSyv0FyBu0eWf5K2UfmUMn7IHGxulj7psg=
+github.com/zetxek/adritian-free-hugo-theme v1.7.5/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -21,9 +21,6 @@
 - id: "logo_text2"
   translation: "Demo"
 
-- id: "nav_home"
-  translation: "HOME"
-
 ## General
 - id: "skipToMainContent"
   translation: "Skip to main content"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -17,8 +17,7 @@
   translation: "Genial"
 - id: "logo_text2"
   translation: "Nombre"
-- id: "nav_home"
-  translation: "INICIO"
+
 
 ## General
 - id: "skipToMainContent"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -17,8 +17,6 @@
   translation: "Cool"
 - id: "logo_text2"
   translation: "Nom"
-- id: "nav_home"
-  translation: "ACCUEIL"
   
 ## General
 - id: "skipToMainContent"


### PR DESCRIPTION
updating to `1.7.5` and content