### PR TITLE
[auto] Update Hugo modules @v1.7.18 → @v1.7.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.18-0.20250509174208-60b825c50116
+require github.com/zetxek/adritian-free-hugo-theme v1.7.18
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.18-0.20250509174208-60b825c50116 h1:W1JNh0NgFxec1AMGzaHPKpRDD+mSdmWEClfp3qyvp4E=
-github.com/zetxek/adritian-free-hugo-theme v1.7.18-0.20250509174208-60b825c50116/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.18 h1:YQe309ovHz8SfXn5pzDn1DBHhE2r62jwFSpHI7iepTw=
+github.com/zetxek/adritian-free-hugo-theme v1.7.18/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.18 to @v1.7.18
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml