### PR TITLE
[auto] Update Hugo modules @v1.7.22 → @v1.7.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523132841-8e7e7c94fa5d
+require github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523183756-6df0f90ede92
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523132841-8e7e7c94fa5d h1:Yxl1Wb3F6ssf4RIXxkLO3WcN10RSJW/eUAvXjS2QwAs=
-github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523132841-8e7e7c94fa5d/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523183756-6df0f90ede92 h1:0/IlbjCZilpMgbjWJdRUfxeVyC5PPf/WhvIVtoWt0+I=
+github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250523183756-6df0f90ede92/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.22 to @v1.7.22
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml