### PR TITLE
[auto] Update Hugo modules @v1.7.22 → @v1.7.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250524100121-bcb3f630ddff
+require github.com/zetxek/adritian-free-hugo-theme v1.7.23
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250524100121-bcb3f630ddff h1:PLgpV8vRkGdgCfPp149yZL91e9ODhOHPUHdK2PmqJIA=
-github.com/zetxek/adritian-free-hugo-theme v1.7.22-0.20250524100121-bcb3f630ddff/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.23 h1:b2IwQOcnAeKMiEV+eOO9Bs+PDIXMqLgDAHmd9+0Slps=
+github.com/zetxek/adritian-free-hugo-theme v1.7.23/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.22 to @v1.7.23
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml