### PR TITLE
[auto] Update Hugo modules @v1.7.25 → @v1.7.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.25-0.20250524165928-539b1b4d7de9
+require github.com/zetxek/adritian-free-hugo-theme v1.7.25
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.25-0.20250524165928-539b1b4d7de9 h1:LO94a30aI9wsx/wt2/TpbvhnQk1BeoFYQJ757qly6vA=
-github.com/zetxek/adritian-free-hugo-theme v1.7.25-0.20250524165928-539b1b4d7de9/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.25 h1:XnRricSFZSlU+U/1gE5eW1jVCNoUuAukoxd1XvhMMLg=
+github.com/zetxek/adritian-free-hugo-theme v1.7.25/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.25 to @v1.7.25
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml