### PR TITLE
[auto] Update Hugo modules @v1.7.25 → @v1.7.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.25
+require github.com/zetxek/adritian-free-hugo-theme v1.7.26
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.25 h1:XnRricSFZSlU+U/1gE5eW1jVCNoUuAukoxd1XvhMMLg=
-github.com/zetxek/adritian-free-hugo-theme v1.7.25/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.26 h1:0PSKfRPDyizPcROlXZvwopKX+U0lheh0WRyn23UztrI=
+github.com/zetxek/adritian-free-hugo-theme v1.7.26/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.25 to @v1.7.26
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml