### PR TITLE
[auto] Update Hugo modules @v1.7.28 → @v1.7.29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.28
+require github.com/zetxek/adritian-free-hugo-theme v1.7.29
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.28 h1:fmVdEhW1Xfyok2mx0ayXXD4AJjyLSa5qGsBZXcd9Mx4=
-github.com/zetxek/adritian-free-hugo-theme v1.7.28/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.29 h1:CJR1nXMmWQ0Wssz2yKNFtjQFE11stzgr1Nlj8968QI0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.29/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@zetxek/adritian-theme-helper": "^1.0.5",
         "autoprefixer": "^10.4.17",
-        "bootstrap": "^5.3.6",
+        "bootstrap": "^5.3.7",
         "bootstrap-print-css": "^1.0.0",
         "postcss": "^8.5.4",
         "postcss-cli": "^11.0.0"
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@zetxek/adritian-theme-helper": "^1.0.5",
     "autoprefixer": "^10.4.17",
-    "bootstrap": "^5.3.6",
+    "bootstrap": "^5.3.7",
     "bootstrap-print-css": "^1.0.0",
     "postcss": "^8.5.4",
     "postcss-cli": "^11.0.0"


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.28 to @v1.7.29
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml