### PR TITLE
[auto] Update Hugo modules @v1.7.30 → @v1.7.30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250725133650-cec67375f6da
+require github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250726192938-8b062a03588e
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250725133650-cec67375f6da h1:LcsvcndtS7vwkLaesM+K6AthaQlBW4NKeutquw06T5U=
-github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250725133650-cec67375f6da/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250726192938-8b062a03588e h1:/R3217XfdPwh/OjGy9eIr93wylDwhZAja0RNmoO+J9c=
+github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250726192938-8b062a03588e/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.30 to @v1.7.30
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml