### PR TITLE
[auto] Update Hugo modules @v1.7.30 → @v1.7.30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zetxek/adritian-demo
 
 go 1.23
 
-require github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250801134535-90ef4e308cf1
+require github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250802100704-98540cc9a373
 
 // for local development
 // replace github.com/zetxek/adritian-free-hugo-theme => ../adritian-free-hugo-theme

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250801134535-90ef4e308cf1 h1:lDTQWBadNkYoQuVli0i/elBTLsAJtHRW7XiOaS1HnZo=
-github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250801134535-90ef4e308cf1/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=
+github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250802100704-98540cc9a373 h1:BQfgZOsb4Nb7DGqDsnbQBAQf5WcQ2Ww+Qxusn6lbL5k=
+github.com/zetxek/adritian-free-hugo-theme v1.7.30-0.20250802100704-98540cc9a373/go.mod h1:RZxMuUPx+AJwqABiHDQWSVEskypgZCqZ0MwOgCvA6o0=


### PR DESCRIPTION
🤖 Automated update of Hugo modules.
  
  Module version changed from @v1.7.30 to @v1.7.30
  
  Created by Github action: https://github.com/zetxek/adritian-demo/actions/workflows/update-hugo-module.yml